### PR TITLE
feat: reject v0.6.0 vaults

### DIFF
--- a/src/abis/VaultABI.ts
+++ b/src/abis/VaultABI.ts
@@ -1451,4 +1451,11 @@ export const LagoonVaultAbi = [
     stateMutability: "nonpayable",
     type: "function",
   },
+  {
+    inputs: [],
+    name: "version",
+    outputs: [{ internalType: "string", name: "", type: "string" }],
+    stateMutability: "pure",
+    type: "function",
+  },
 ] as const;

--- a/src/cli/find-claimable-controllers.ts
+++ b/src/cli/find-claimable-controllers.ts
@@ -45,7 +45,7 @@ Examples:
       });
       if (version === "v0.6.0") {
         throw new Error(
-          `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock}. This tool does not support v0.6.0 vaults. Use an earlier block (before the upgrade) to compute fees.`
+          `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock}. This tool does not support v0.6.0 vaults. Use an earlier block (before the upgrade) or wait for support. ETA: middle of May 2026`
         );
       }
 

--- a/src/cli/find-claimable-controllers.ts
+++ b/src/cli/find-claimable-controllers.ts
@@ -7,6 +7,7 @@ import { fetchAllVaultEvents } from "utils/fetchVaultEvents";
 import { generateVault } from "core/vault";
 import { parseVaultArgument } from "parsing/parseVault";
 import { LagoonVaultAbi } from "abis/VaultABI";
+import { fetchVaultVersion } from "utils/fetchVaultVersion";
 
 export function setControllersCommand(command: Command) {
   command
@@ -36,6 +37,17 @@ Examples:
       const toBlock = options.block ? BigInt(options.block) : (
         await client.getBlock({ blockTag: "latest" })
       ).number;
+
+      const version = await fetchVaultVersion({
+        chainId: vault.chainId,
+        address: vault.address,
+        block: toBlock,
+      });
+      if (version === "v0.6.0") {
+        throw new Error(
+          `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock}. This tool does not support v0.6.0 vaults. Use an earlier block (before the upgrade) to compute fees.`
+        );
+      }
 
       const vaultEvents = await fetchAllVaultEvents({
         chainId: vault.chainId,

--- a/src/core/processEvents.ts
+++ b/src/core/processEvents.ts
@@ -4,6 +4,7 @@ import { checkStrictBlockNumberMatching } from "./strictBlockNumberMatching";
 import type { ProcessVaultParams, ProcessVaultReturn } from "./types";
 import { preprocessEvents } from "./preprocessEvents";
 import { fetchAllVaultEvents } from "utils/fetchVaultEvents";
+import { fetchVaultVersion } from "utils/fetchVaultVersion";
 
 export async function processEvents({
   vault,
@@ -18,6 +19,17 @@ export async function processEvents({
   strictBlockNumberMatching = true,
 }: ProcessVaultParams): Promise<ProcessVaultReturn> {
   console.log(`Loading vault ${vault.address} on chain ${vault.chainId}`);
+
+  const version = await fetchVaultVersion({
+    chainId: vault.chainId,
+    address: vault.address,
+    block: toBlock ? BigInt(toBlock) : undefined,
+  });
+  if (version === "v0.6.0") {
+    throw new Error(
+      `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock ?? "latest"}. This tool does not support v0.6.0 vaults. Use an earlier toBlock (before the upgrade) to compute fees.`
+    );
+  }
 
   const vaultEvents = await fetchAllVaultEvents({
     chainId: vault.chainId,

--- a/src/core/processEvents.ts
+++ b/src/core/processEvents.ts
@@ -27,7 +27,7 @@ export async function processEvents({
   });
   if (version === "v0.6.0") {
     throw new Error(
-      `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock ?? "latest"}. This tool does not support v0.6.0 vaults. Use an earlier toBlock (before the upgrade) to compute fees.`
+      `Vault ${vault.address} on chain ${vault.chainId} is at version v0.6.0 at block ${toBlock}. This tool does not support v0.6.0 vaults. Use an earlier block (before the upgrade) or wait for support. ETA: middle of May 2026`
     );
   }
 

--- a/src/utils/fetchVaultVersion.ts
+++ b/src/utils/fetchVaultVersion.ts
@@ -1,0 +1,32 @@
+import { LagoonVaultAbi } from "abis/VaultABI";
+import { publicClient } from "../lib/publicClient";
+import type { Address } from "viem";
+
+// Returns the on-chain version string of the vault at the given block.
+// Vaults that predate the version() function (pre-v0.5.1) revert; we treat
+// those as "v0.2.0".
+export async function fetchVaultVersion({
+  chainId,
+  address,
+  block,
+}: {
+  chainId: number;
+  address: Address;
+  block?: bigint;
+}): Promise<string> {
+  const client = publicClient[chainId];
+  if (!client) {
+    throw new Error(`Missing client for chaindId : ${chainId}`);
+  }
+
+  try {
+    return await client.readContract({
+      address,
+      abi: LagoonVaultAbi,
+      functionName: "version",
+      blockNumber: block,
+    });
+  } catch {
+    return "v0.2.0";
+  }
+}


### PR DESCRIPTION
## Summary
- Read the on-chain vault `version()` at the last covered block and abort with a clear error if it returns `v0.6.0` — this tool doesn't support v0.6.0 yet.
- Pre-v0.5.1 vaults that lack `version()` are treated as `v0.2.0`, so the existing flows keep working.
- Check is wired into `processEvents` (covers `period-fee`, `user-fee`, `user-points`, `user-balance`, `find-blocks`) and into `find-claimable-controllers` (which bypasses `processEvents`).

## Caveats
- Imperfect by design: a vault that downgrades back from v0.6.0 would still be blocked at any `toBlock` where it currently reads as v0.6.0. Good enough for now.

## Test plan
- [ ] Run `period-fee` against a non-v0.6.0 vault — completes as before.
- [ ] Run `period-fee` against a v0.6.0 vault — aborts with the version error.
- [ ] Run `period-fee` against a pre-v0.5.1 vault (no `version()`) — completes (treated as v0.2.0).