### PR TITLE
feat: refund-hwm command (per-wallet HWM performance-fee refund)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { setControllersCommand } from "cli/find-claimable-controllers";
 import { setPeriodFeeCommand } from "cli/period-fee";
 import { setInterpolateCommand } from "cli/interpolate";
 import { setUserPointsCommand } from "cli/user-points";
+import { setRefundHwmCommand } from "cli/refund-hwm";
 
 export const computationProgram = new Command();
 
@@ -18,6 +19,7 @@ computationProgram
 setBlocksCommand(computationProgram);
 setUserFeeCommand(computationProgram);
 setUserPointsCommand(computationProgram);
+setRefundHwmCommand(computationProgram);
 setControllersCommand(computationProgram);
 setPeriodFeeCommand(computationProgram);
 setInterpolateCommand(computationProgram);

--- a/src/cli/refund-hwm.ts
+++ b/src/cli/refund-hwm.ts
@@ -1,0 +1,136 @@
+import { parseRebateDeals } from "parsing/parseRebateDeals";
+import { parseHwmOverrides } from "parsing/parseHwmOverrides";
+import { parseVaultArgument } from "parsing/parseVault";
+import type { Command } from "@commander-js/extra-typings";
+import { filterWildCard } from "utils/various";
+import { formatUnits } from "viem";
+import { computationApi, type RefundHwmResult } from "lib/computationApi";
+
+export function setRefundHwmCommand(command: Command) {
+  command
+    .command("refund-hwm")
+    .alias("rhwm")
+    .description(
+      "Compute, per wallet, the performance fees to refund after the vault high-water mark is reset (v0.6.0 resetHighWaterMark). \
+A personal high-water mark is tracked per deposit lot: the highest price per share the lot has already paid performance fees on. \
+Fees charged on a price recovery below that mark were already paid before the drawdown, so they must be refunded by the fee receiver. \
+The output is a csv with the following columns: chainId, vault, wallet, perfFees, refund, refundGross, highWaterMark, pricePerShare. \
+Amounts are raw vault shares (the fee receiver sends shares back); use -r for human units. \
+This command requires precise block input. The fromBlock and the toBlock must correspond to totalAssets updates blockNumber. \
+The nominal workflow is to run it at each settlement with fromBlock = the last settlement already refunded.\n"
+    )
+    .argument(
+      "chainId:VaultAddress",
+      "The chain ID and vault address to compute refunds for\n",
+      parseVaultArgument
+    )
+    .option(
+      "-f, --from-block <number>",
+      "Starting block number for refund computation (exclusive). If not provided, uses the oldest totalAssetsUpdated block. Use 'find-blocks' command to find the appropriate block number\n"
+    )
+    .option(
+      "-t, --to-block <number>",
+      "Ending block number for refund computation (inclusive). If not provided, uses the newest totalAssetsUpdated block. Use 'find-blocks' command to find the appropriate block number\n"
+    )
+    .option(
+      "-r, --readable",
+      "Format the output in a human-readable format\n",
+      false
+    )
+    .option(
+      "-o, --output",
+      "Will save the result in output/refund-hwm in a file with following format: <chainId>-<vaultAddress>-<from-block>-<to-block>.csv"
+    )
+    .option(
+      "--silent",
+      "This will prevent the printing of the output on stdout\n",
+      false
+    )
+    .option(
+      "-d, --deals <string>",
+      `Path to the csv file containing OTC (Over-The-Counter) deals on the fee rebate. \
+A deal reduces the refund to the perf fees the wallet still bears after its rebate (no double refund). \
+The amount of % is express in 10^2. For example, 8% is express 800 in the csv file. \
+0, 0x0 is a wildcard for all vaults on any chain. \
+Format: chainId,vault,address,rebateRateBps \
+Example:  1,0x07ed4...cb90D9B,0x123456...67890,1000\n`,
+      parseRebateDeals
+    )
+    .option(
+      "--hwm <string>",
+      `Path to a csv file of personal high-water-mark overrides, for LPs migrating \
+with a historical drawdown from outside the vault (e.g. a segregated account). \
+The value is the price per share (asset units, decimal) the LP must recover before \
+paying performance fees again, translated relative to its entry price: an LP entering \
+when the price per share is 1.1 with a 50% historical drawdown gets 2.2. \
+Applied once, on the wallet's first acquisition. \
+The first line is a header and is ignored. A duplicated wallet is an error. \
+Format: wallet,hwmPricePerShare \
+Example: 0x123456...67890,2.2\n`,
+      parseHwmOverrides
+    )
+    .addHelpText(
+      "after",
+      `
+Example:
+  $ bun rhwm 1:0x07ed467acd4ffd13023046968b0859781cb90d9b -f 1000000 -t 2000000 -r -o
+    `
+    )
+    .action(async (vault, options) => {
+      // The backend filters deals to this vault itself, but its wildcard sentinel
+      // is the zero-address — not the CLI's "0x0". Resolve wildcards here and send
+      // concrete (chainId, vault) entries so nothing is rejected.
+      const scope = { chainId: vault.chainId, vault: vault.address };
+      const rebateDeals = filterWildCard(await options.deals, vault).map((d) => ({
+        ...d,
+        ...scope,
+      }));
+
+      const result = await computationApi.refundHwm(vault.chainId, vault.address, {
+        fromBlock: options.fromBlock,
+        toBlock: options.toBlock,
+        hwmOverrides: await options.hwm,
+        rebateDeals,
+      });
+
+      const csv = convertToCSV(result, options.readable);
+      if (!options.silent) {
+        console.log(csv);
+      }
+      if (options.output) {
+        try {
+          const file = Bun.file(
+            `./output/refund-hwm/${vault.chainId}-${vault.address}-${options.fromBlock}-${options.toBlock}.csv`
+          );
+          await file.write(csv);
+          console.log(`CSV report written to: ${file.name}`);
+        } catch (error: any) {
+          console.error("Error writing CSV file:", error.message);
+          console.log("CSV content:");
+          console.log(csv);
+        }
+      }
+    });
+}
+
+function convertToCSV(result: RefundHwmResult, readable: boolean) {
+  // Amounts come back as raw wei; format with the vault decimals only when -r.
+  const amount = (v: string) =>
+    readable ? formatUnits(BigInt(v), result.decimals) : v;
+  const price = (v: string) =>
+    readable ? formatUnits(BigInt(v), result.assetDecimals) : v;
+
+  const pricePerShare = price(result.pricePerShare);
+  const highWaterMark = price(result.highWaterMark);
+
+  const csvRows = [
+    `chainId,vault,wallet,perfFees,refund,refundGross,highWaterMark,pricePerShare`,
+    ...result.rows.map(
+      (d) =>
+        `${result.chainId},${result.vault},${d.account},${amount(
+          d.perfFees
+        )},${amount(d.refund)},${amount(d.refundGross)},${highWaterMark},${pricePerShare}`
+    ),
+  ];
+  return csvRows.join("\n");
+}

--- a/src/lib/computationApi.ts
+++ b/src/lib/computationApi.ts
@@ -1,9 +1,10 @@
 import { get } from "env-var";
 
-// Default points at the Lagoon backend (computation API + GraphQL); override with
-// COMPUTATION_API_URL to target another environment.
+// Default points at the prod Lagoon backend (computation API + GraphQL). Override
+// with COMPUTATION_API_URL to test against another environment, e.g.
+// https://api-pprod.lagoon.finance.
 const BASE_URL = get("COMPUTATION_API_URL")
-  .default("https://api-pprod.lagoon.finance")
+  .default("https://api.lagoon.finance")
   .asString();
 
 export type PeriodFeeRow = {

--- a/src/lib/computationApi.ts
+++ b/src/lib/computationApi.ts
@@ -1,9 +1,9 @@
 import { get } from "env-var";
 
-// Default points at the preview; override with COMPUTATION_API_URL. Swapped to
-// the real endpoint before the PR.
+// Default points at the Lagoon backend (computation API + GraphQL); override with
+// COMPUTATION_API_URL to target another environment.
 const BASE_URL = get("COMPUTATION_API_URL")
-  .default("https://api.lagoon.finance")
+  .default("https://api-pprod.lagoon.finance")
   .asString();
 
 export type PeriodFeeRow = {

--- a/src/lib/computationApi.ts
+++ b/src/lib/computationApi.ts
@@ -56,6 +56,23 @@ export type UserPointsResult = {
   rows: { account: string; points: Record<string, number> }[];
 };
 
+export type RefundRow = {
+  account: string;
+  perfFees: string;
+  refund: string;
+  refundGross: string;
+};
+
+export type RefundHwmResult = {
+  chainId: number;
+  vault: string;
+  decimals: number;
+  assetDecimals: number;
+  pricePerShare: string;
+  highWaterMark: string;
+  rows: RefundRow[];
+};
+
 // POST a computation request and return the parsed JSON body. On a non-2xx the
 // backend sends { message }, which we surface verbatim so the CLI prints the
 // same clear errors it used to throw locally (invalid block, zero supply, ...).
@@ -86,6 +103,8 @@ export const computationApi = {
     post<UserFeesResult>(`/computation/${chainId}/${vault}/user-fees`, body),
   userPoints: (chainId: number, vault: string, body: object) =>
     post<UserPointsResult>(`/computation/${chainId}/${vault}/user-points`, body),
+  refundHwm: (chainId: number, vault: string, body: object) =>
+    post<RefundHwmResult>(`/computation/${chainId}/${vault}/refund-hwm`, body),
 };
 
 // GraphQL query against the Lagoon indexer (api.lagoon.finance/query).

--- a/src/parsing/parseHwmOverrides.ts
+++ b/src/parsing/parseHwmOverrides.ts
@@ -1,0 +1,45 @@
+import { isAddress, type Address } from "viem";
+
+// A per-wallet personal high-water-mark override, for LPs migrating with a
+// pre-existing drawdown from outside the vault. `pricePerShare` is a decimal in
+// asset units (e.g. "2.2"), applied once on the wallet's first acquisition.
+export type HwmOverride = { wallet: Address; pricePerShare: string };
+
+// Positive decimal in asset units.
+const DECIMAL = /^\d+(\.\d+)?$/;
+
+export async function parseHwmOverrides(
+  filePath: string
+): Promise<HwmOverride[]> {
+  if (!filePath.endsWith(".csv")) {
+    throw new Error("File must have .csv extension");
+  }
+  const rows = (await Bun.file(filePath).text()).split("\n");
+  const seen = new Set<Address>();
+  const overrides: HwmOverride[] = [];
+
+  for (const entry of rows.slice(1)) {
+    const line = entry.trim();
+    if (line === "") continue;
+    const [walletRaw, pricePerShare] = line.replace(" ", "").split(",") as [
+      Address,
+      string,
+    ];
+    if (!isAddress(walletRaw)) {
+      throw new Error(`Invalid wallet address in HWM overrides file: ${walletRaw}`);
+    }
+    if (!DECIMAL.test(pricePerShare ?? "")) {
+      throw new Error(
+        `Invalid pricePerShare "${pricePerShare}" for ${walletRaw} (decimal in asset units, e.g. 2.2)`
+      );
+    }
+    const wallet = walletRaw.toLowerCase() as Address;
+    // It's a payment file: a duplicated wallet is an error, not a silent merge.
+    if (seen.has(wallet)) {
+      throw new Error(`Duplicate wallet in HWM overrides file: ${wallet}`);
+    }
+    seen.add(wallet);
+    overrides.push({ wallet, pricePerShare });
+  }
+  return overrides;
+}


### PR DESCRIPTION
Adds a `refund-hwm` command (alias `rhwm`) — a thin client over the backend's new `POST /computation/:chainId/:vault/refund-hwm` (backend PR hopperlabsxyz/backend#312).

## What
Computes, per wallet, the performance fees to refund after an on-chain HWM reset (v0.6.0 `resetHighWaterMark`). A personal HWM is tracked **per deposit lot**; fees charged on a price recovery below a lot's mark were already paid before a drawdown, so the fee receiver returns them.

## Changes
- `lib/computationApi`: `RefundHwmResult` type + `refundHwm()` POST.
- `cli/refund-hwm` (alias `rhwm`): `-f/-t` blocks, `-r`, `-o`, `--silent`, `-d` deals (a deal reduces the refund to the perf fees the wallet still bears — no double refund), `--hwm` per-wallet HWM overrides for migrating LPs. Mirrors `user-fee`.
- `parsing/parseHwmOverrides`: `wallet,pricePerShare` CSV; a duplicated wallet is an error.
- Registered in `index.ts`.

Output CSV: `chainId,vault,wallet,perfFees,refund,refundGross,highWaterMark,pricePerShare` (raw wei; `-r` for human units).

## Status
- `tsc --noEmit` clean; `--help` and the `rhwm` alias render.
- End-to-end returns **404 until backend #312 is merged & deployed** — the endpoint isn't on prod yet. The client correctly reaches it and surfaces the error. Once deployed, the default `COMPUTATION_API_URL` reaches it; override the env for preview backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)